### PR TITLE
Nightly AWS cloud build now includes building J7200 target first, then AM65X and saving both images

### DIFF
--- a/iGOS-daily-build.sh
+++ b/iGOS-daily-build.sh
@@ -1,9 +1,19 @@
-cd ~/nexus-build
+sudo rm -rf nexus-build
+git clone https://github.com/psleng/nexus-build
+cd nexus-build
 echo 'Starting daily iGOS build...' > iGOS-build.out
 date >> iGOS-build.out
-git pull
+echo 'Starting targ-ti-j7200 iGOS build...' >> iGOS-build.out
+date >> iGOS-build.out
+make targ-ti-j7200
+make all
+echo 'Finished targ-ti-j7200 iGOS build...' >> iGOS-build.out
+date >> iGOS-build.out
+ls -l .*built >>  iGOS-build.out
 make clean
-make targ-ti-evm
+echo 'Starting targ-ti-am64x iGOS build...' >> iGOS-build.out
+date >> iGOS-build.out
+make targ-ti-am64x
 make all
 ls -l .*built >>  iGOS-build.out
 date >> iGOS-build.out


### PR DESCRIPTION
Minor update to the nightly build script that builds images for both ARM64 targets, save the images and update the psleng.github.io deb repo. 