### PR TITLE
Mostly automated upstream merging support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,23 +34,34 @@ help:
 	    cat $(DEFS); \
 	fi
 
+# List of iGOS packages to build.
+# This is used in build_iGOS_TMDS64EVM_fs.sh and others.
+IGOS_PKGS='vyos-1x vyatta-bash vyos-user-utils vyatta-biosdevname \
+        libvyosconfig vyatta-cfg vyos-http-api-tools vyos-utils \
+        ipaddrcheck udp-broadcast-relay hvinfo vyatta-wanloadbalance \
+        libmnl libpam-radius-auth initramfs-tools libnss-mapuser \
+        tacacs live-boot'
+
 # target build: TI TMDS64EVM board (default)
 # BUILDTYPE is a builds entry from ti-bdebstrap/builds.toml
 $(DEFS) targ-ti-am64x:
 	@test `arch` = aarch64 || { echo "WARNING: building for this target on this machine (`arch`) is not supported" >&2; }
 	@echo BUILDTARG=ti-evm > $(DEFS)
 	@echo BUILDTYPE=bookworm-am64xx-evm >> $(DEFS)
+	@echo IGOS_PKGS="$(IGOS_PKGS)" >> $(DEFS)
 
 # target build: TI J7200 board
 targ-ti-j7200:
 	@test `arch` = aarch64 || { echo "WARNING: building for this target on this machine (`arch`) is not supported" >&2; }
 	@echo BUILDTARG=ti-evm > $(DEFS)
 	@echo BUILDTYPE=bookworm-j7200-evm >> $(DEFS)
+	@echo IGOS_PKGS="$(IGOS_PKGS)" >> $(DEFS)
 
 # target build: x86_64
 targ-x86:
 	@test `arch` = x86_64 || { echo "WARNING: building for this target on this machine (`arch`) is not supported" >&2; }
 	@echo BUILDTARG=x86_64 > $(DEFS)
+	@echo IGOS_PKGS="$(IGOS_PKGS)" >> $(DEFS)
 
 
 # Base repository to use for all container build recipes.

--- a/build_iGOS_TMDS64EVM_fs.sh
+++ b/build_iGOS_TMDS64EVM_fs.sh
@@ -77,13 +77,7 @@ TSK=package-build-iGOS
 BLT=.filesystem.$TSK.built
 if [ ! -f "$BLT" ]; then
     echo "=== I: $0: package-build.py $TSK BEGIN"
-    ./package-build.py --dir $TSK --include \
-        vyos-1x vyatta-bash vyos-user-utils vyatta-biosdevname \
-        libvyosconfig vyatta-cfg vyos-http-api-tools vyos-utils \
-        ipaddrcheck udp-broadcast-relay hvinfo vyatta-wanloadbalance \
-        libmnl libpam-radius-auth initramfs-tools libnss-mapuser \
-        tacacs live-boot
-
+    ./package-build.py --dir $TSK --include $IGOS_PKGS
     touch "$BLT" # build success
 else
     echo "=== I: $0: SKIP package-build.py $TSK ($BLT exists)"

--- a/repo-maintenance/.gitignore
+++ b/repo-maintenance/.gitignore
@@ -1,0 +1,2 @@
+/work
+.mypy_cache

--- a/repo-maintenance/README.md
+++ b/repo-maintenance/README.md
@@ -1,0 +1,12 @@
+# REPO MAINTENANCE
+
+This directory contains programs useful for repository maintenance.
+
+### merge-from-upstream.py
+
+This will automatically merge all vyos upstream repositories
+used by package-build-iGOS that are in use into our "current"
+branch (for the most part).  If all merges succeed, which they
+normally should because that branch should effectively be a copy
+of the vyos branch, it will tell you which got updated so you have
+a chance to go each one of them and do the `git commit` and `git push`.

--- a/repo-maintenance/merge-from-upstream.py
+++ b/repo-maintenance/merge-from-upstream.py
@@ -1,0 +1,189 @@
+#!/usr/bin/python3
+'''
+Merge from upstream on all iGOS packages.
+'''
+import os
+from subprocess import run
+from pathlib import Path
+try:
+    import tomli
+except ModuleNotFoundError:
+    os.system('sudo apt install python3-tomli')
+    import tomli
+
+
+# All the repository merging takes place under this directory.
+WORKDIR = 'work'
+
+
+def findup(targ: str) -> (Path | None):
+    '''
+    Look upwards from the current directory until a file or
+    directory "targ" is found.  Returns resulting path or None
+    '''
+    dirpath = Path('.')
+    root = Path('/')
+    while dirpath.resolve() != root:
+        dst = Path(dirpath, targ)
+        if dst.exists():
+            return dst
+        dirpath = dirpath.joinpath('..')
+    return None
+
+
+def merge_from_upstream(dpkg: dict) -> str:
+    '''
+    Do the merge from upstream work.
+    '''
+    workdir = Path(WORKDIR, dpkg['name'])
+    if os.path.exists(workdir):
+        print(f' I: directory "{workdir}" already exists; skipping')
+        return str(workdir)
+
+    name = dpkg['name']
+    url = dpkg['scm_url']
+
+    # We *could* use the python "git" module here, but it is likely
+    # easier for humans to understand what is going on by using
+    # git cli directly.
+
+    # Clone ours (psleng)
+    assert 'psleng' in url
+    print(f' I: Cloning {name}')
+    run(['git', 'clone', '-q', url, workdir], check=True)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(workdir)
+        # Add the corresponding vyos upstream
+        run(['git', 'remote', 'add', 'upstream',
+             f'https://github.com/vyos/{name}.git'], check=True)
+        run(['git', 'fetch', '-q', '--tags', '--all'], check=True)
+        r = run(['git', 'branch', '--show-current'],
+                capture_output=True, check=True)
+        origbranch = r.stdout.decode().strip()
+
+        # Decide on the name of the upstream branch.
+        # Prefer "current" if available remotely, otherwise use existing.
+        # This happens for packages like libmnl
+        branch = 'current'
+        r = run(['git', 'branch', '--list', '--remotes'],
+                capture_output=True, check=True)
+        if f'upstream/{branch}' not in r.stdout.decode():
+            # Use existing psleng branch if upstream has it
+            print(f' I: Cannot find upstream/{branch}')
+            r = run(['git', 'branch', '--show-current'],
+                    capture_output=True, check=True)
+            branch = r.stdout.decode().strip()
+            if branch == 'psl-master':
+                # Will not exist upstream.  Pick master or first upstream.
+                upstreams = os.listdir('.git/refs/remotes/upstream')
+                print(f' I: available upstream branches: {upstreams}')
+                if 'master' in upstreams:
+                    branch = 'master'
+                else:
+                    branch = upstreams[0]
+            print(f' I: Using {branch} as the upstream')
+
+        # Make the branch if not already in place
+        if not Path(f'.git/refs/heads/{branch}').exists():
+            print(f' I: No "{branch}" branch; making it')
+            r = run(['git', 'checkout', '-q',
+                     '--track', f'origin/{branch}'])
+            if r.returncode:
+                print(f' I: Failed; falling back to {origbranch}')
+                branch = origbranch
+
+        if branch == 'psl-master':
+            # No branch found
+            print(' E: Cannot find a reasonable upstream branch to merge')
+            exit(1)
+
+        # Finally, do the merge from upstream
+        run(['git', 'merge', '-q', '--no-commit', f'upstream/{branch}'],
+            check=True)
+        print(' I: Merge succeeded!')
+
+    finally:
+        os.chdir(cwd)
+
+    return str(workdir)
+
+
+################################
+
+# Find top level directory
+topdir = findup('.git')
+if not topdir:
+    raise FileNotFoundError('.git')
+topdir = topdir.parent
+
+# .defs.mk should be there
+defsmk = topdir.joinpath('.defs.mk')
+if not Path(defsmk).exists():
+    print('E: Cannot locate .defs.mk')
+    exit(1)
+
+# Parse IGOS_PKGS from .defs.mk
+igos_pkgs = []
+with open(defsmk) as fp:
+    for i in fp.readlines():
+        if not i.startswith('IGOS_PKGS'):
+            continue
+        # Take value portion, remove leading/trailing "'", listify
+        igos_pkgs = i.split('=', 1)[-1].strip().strip("'").split()
+
+if not igos_pkgs:
+    print(f'E: Cannot find IGOS_PKGS in {defsmk}')
+    exit(1)
+
+# The directory containing packages with package.toml files
+IGOSPATH = Path(topdir, 'package-build-iGOS')
+
+# Create the new workdir
+if Path(WORKDIR).exists():
+    print(f'E: Directory "{WORKDIR}" already exists from a previous run.')
+    print('E: Examine it and either push the changes in it or remove it.')
+    exit(1)
+os.mkdir(WORKDIR)
+
+# Try to merge from upstream all the repos listed in the packages
+workdirs = []
+for pkg in igos_pkgs:
+    print(f'\nI: Processing {pkg}')
+
+    pkgtoml = Path(IGOSPATH, pkg, 'package.toml')
+    if not pkgtoml.exists():
+        print(f'E: {pkgtoml} not found but is in {defsmk}!')
+        exit(1)
+
+    # Parse the toml
+    toml = tomli.load(open(pkgtoml, 'rb'))
+    pkgs: dict = toml['packages']
+    for dpkg in pkgs:
+        workdirs.append(merge_from_upstream(dpkg))
+
+# Special case: vyos-build (does not use package.toml)
+# Cook up what the parsed package.toml part would look like.
+dpkg = {'name': 'vyos-build',
+        'scm_url': 'git@github.com:psleng/vyos-build'}
+print(f'\nI: Processing {dpkg["name"]}')
+workdirs.append(merge_from_upstream(dpkg))
+
+# It all worked.  Print a list of directories needing to be committed/pushed.
+topush = []
+for workdir in workdirs:
+    if Path(workdir, '.git', 'MERGE_HEAD').exists():
+        topush.append(workdir)
+
+print('==============')
+if topush:
+    print('The following directories need to be committed and pushed:\n')
+    for i in topush:
+        print(f'\t{i}')
+    print('\nThis will bring us up to date with the VyOS upstream.')
+    print('After that, you can go into each and try merging that')
+    print('into the corresponding psleng branch.')
+
+else:
+    print('No changes needs to be committed/pushed.')


### PR DESCRIPTION
- The list of iGOS packages is now put into .defs.mk instead of being
  hardcoded into build_iGOS_TMDS64EVM_fs.sh
- This means we can adjust it based on the target if necessary.
- The new "repo-maintenance" directory is intended for repository maintenance.
- "repo-maintenance/merge-from-upstream.py" is a python script that uses
  the list of active iGOS packages from .defs.mk to automatically check
  out all the repositories and merge from upstream.
- When it completes successfully, which should always happen since
  the psleng "current" should never have changes from upstream,
  you can then commit/push the changed repos.
- You can then embark on trying to merge from "current" to "psl-master"
  which is where you are more likely to get conflicts.
