### PR TITLE
Enhancements to look for prod_id=XXXXX and model=YYZZ in the /proc/cmdline and /etc/product.env to select prod/model specific config-XXXXX-YYZZ default config file from our list to use

### DIFF
--- a/build_iGOS_TMDS64EVM_fs.sh
+++ b/build_iGOS_TMDS64EVM_fs.sh
@@ -244,6 +244,8 @@ if [ ! -f "$BLT" ]; then
     sudo cp updates/perle-init.service $FS/lib/systemd/system
     sudo ln -s /lib/systemd/system/perle-init.service $FS/etc/systemd/system/multi-user.target.wants/perle-init.service
     sudo cp updates/perle-init.sh $FS/usr/bin
+    sudo cp -rf updates/model-info $FS/usr/share/vyos/
+    sudo cp -rf updates/product.env $FS/etc/
 
     # Generate a default locale (stops warnings from perl)
     if [ ! -f $FS/usr/lib/locale/locale-archive ]; then

--- a/updates/model-info/default-config/config-IOLAN-1000
+++ b/updates/model-info/default-config/config-IOLAN-1000
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-1
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2A00
+++ b/updates/model-info/default-config/config-IOLAN-2A00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2a
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2A01
+++ b/updates/model-info/default-config/config-IOLAN-2A01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2a
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2B00
+++ b/updates/model-info/default-config/config-IOLAN-2B00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2b
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2B01
+++ b/updates/model-info/default-config/config-IOLAN-2B01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2b
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2C00
+++ b/updates/model-info/default-config/config-IOLAN-2C00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2c
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2C01
+++ b/updates/model-info/default-config/config-IOLAN-2C01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2c
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2D00
+++ b/updates/model-info/default-config/config-IOLAN-2D00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2d
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2D01
+++ b/updates/model-info/default-config/config-IOLAN-2D01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2d
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2E00
+++ b/updates/model-info/default-config/config-IOLAN-2E00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2e
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2E01
+++ b/updates/model-info/default-config/config-IOLAN-2E01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2e
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2F00
+++ b/updates/model-info/default-config/config-IOLAN-2F00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2f
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-2F01
+++ b/updates/model-info/default-config/config-IOLAN-2F01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-2f
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-3000
+++ b/updates/model-info/default-config/config-IOLAN-3000
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-3
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-3001
+++ b/updates/model-info/default-config/config-IOLAN-3001
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-3
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4A00
+++ b/updates/model-info/default-config/config-IOLAN-4A00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4a
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4A01
+++ b/updates/model-info/default-config/config-IOLAN-4A01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4a
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4B00
+++ b/updates/model-info/default-config/config-IOLAN-4B00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4b
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4B01
+++ b/updates/model-info/default-config/config-IOLAN-4B01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4b
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4C00
+++ b/updates/model-info/default-config/config-IOLAN-4C00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4c
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4C01
+++ b/updates/model-info/default-config/config-IOLAN-4C01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4c
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4D00
+++ b/updates/model-info/default-config/config-IOLAN-4D00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4d
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4D01
+++ b/updates/model-info/default-config/config-IOLAN-4D01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4d
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4E00
+++ b/updates/model-info/default-config/config-IOLAN-4E00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4e
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4E01
+++ b/updates/model-info/default-config/config-IOLAN-4E01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4e
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4F00
+++ b/updates/model-info/default-config/config-IOLAN-4F00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4f
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4F01
+++ b/updates/model-info/default-config/config-IOLAN-4F01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4f
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4G00
+++ b/updates/model-info/default-config/config-IOLAN-4G00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4g
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4G01
+++ b/updates/model-info/default-config/config-IOLAN-4G01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4g
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4H00
+++ b/updates/model-info/default-config/config-IOLAN-4H00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4h
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IOLAN-4H01
+++ b/updates/model-info/default-config/config-IOLAN-4H01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name Iolan-4h
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IRG-1000
+++ b/updates/model-info/default-config/config-IRG-1000
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name irg-1
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IRG-1A00
+++ b/updates/model-info/default-config/config-IRG-1A00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name irg-1a
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IRG-1B00
+++ b/updates/model-info/default-config/config-IRG-1B00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name irg-1b
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IRG-2000
+++ b/updates/model-info/default-config/config-IRG-2000
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name irg-2
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IRG-2001
+++ b/updates/model-info/default-config/config-IRG-2001
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name irg-2
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IRG-2A00
+++ b/updates/model-info/default-config/config-IRG-2A00
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name irg-2a
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IRG-2A01
+++ b/updates/model-info/default-config/config-IRG-2A01
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name irg-2a
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IRG-3000
+++ b/updates/model-info/default-config/config-IRG-3000
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name irg-3
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IRG-3001
+++ b/updates/model-info/default-config/config-IRG-3001
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name irg-3
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IT-1000
+++ b/updates/model-info/default-config/config-IT-1000
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name it-1
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IT-1001
+++ b/updates/model-info/default-config/config-IT-1001
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name it-1
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IT-2000
+++ b/updates/model-info/default-config/config-IT-2000
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name it-2
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/model-info/default-config/config-IT-2001
+++ b/updates/model-info/default-config/config-IT-2001
@@ -1,0 +1,56 @@
+interfaces {
+    loopback lo {
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "127.0.0.0/8"
+            address "169.254.0.0/16"
+            address "10.0.0.0/8"
+            address "172.16.0.0/12"
+            address "192.168.0.0/16"
+            address "::1/128"
+            address "fe80::/10"
+            address "fc00::/7"
+        }
+        server 0.pool.ntp.org {
+        }
+        server 1.pool.ntp.org {
+        }
+        server 2.pool.ntp.org {
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    console {
+        device ttyS2 {
+            speed 115200
+        }
+        device ttyS3 {
+            speed 115200
+        }
+    }
+    host-name it-2
+    login {
+        user igos {
+            authentication {
+                encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'
+                plaintext-password ""
+            }
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}

--- a/updates/product.env
+++ b/updates/product.env
@@ -1,0 +1,2 @@
+prod_id=IOLAN
+model=2A01


### PR DESCRIPTION
We needed a way to use specific default config boot files based on product family and models/submodels.  The previous Perle products used 1) perle_product.h header file that included very specific product family, variants, hardware switchport re-mapping, etc 2) default json config database and 3) INITDB startup code that crafted our default json config file.   

In our VYOS-only environment, it would be easier to keep the following concepts of the bootloader passing in product id (family), and models/variants using kernel command line (/proc/cmdline) and/or and env file under /etc/product.env.  For the time being, we use the following strings:  prod_id=IOLAN | IRG | IT and model=YYZZ where YY is the model and ZZ is the sub-model or variant (with or without cellular, or wifi)   A future addition would be the starting MAC address for each unit assigned by production.  Currently, eth0 is assigned TI's OUI 1C:63:49:XX:XX:XX and subsequent ethX are auto generated.   If either prid_id or model cannot be found in /proc/cmdline or /etc/product.env, the generic config.bott.default file will be used.  For testing, a nexus-build/updates/product.env with prod_id=IOLAN  model=2A01 will be copied to build/fs/etc/product.env to be included in the rootfs.  

The list of config-XXXXX-YYZZ files specific to a prod_id=XXXXX and model=YYZZ, will be copied for nexus-build/updates/model-info/default-config/  to the rootfs user /usr/share/vyos/model-info/default-config for now, but they can be moved elsewhere if we see to need to be able to update those without rebuilding the rootfs in the future.  The usr/libexec/vyos/init/vyos-router script would need to change to stay in sync.  List of iGOS product models on Dropbox:
                          Perle Systems Dropbox\Perle\Hardware\iGOS\Models\Proposed 202501081601.xlsx