### PR TITLE
B12006/9999: preseed/automate new VPP package so build can run unattended

### DIFF
--- a/Dockerfile-aarch64
+++ b/Dockerfile-aarch64
@@ -471,6 +471,10 @@ RUN apt-get update && apt-get install -y \
 	perl-xs-dev \
 	default-libmysqlclient-dev
 
+# Packages needed for debconf preseed selection of vpp - DK
+RUN apt-get update && apt-get install -y \
+	debconf-utils
+
 # Packages needed for keepalived
 RUN apt-get install -y \
     libipset-dev libnfnetlink-dev libnftnl-dev libnl-nf-3-dev libpopt-dev

--- a/Dockerfile-x86_64
+++ b/Dockerfile-x86_64
@@ -467,6 +467,10 @@ RUN apt-get update && apt-get install -y \
 	perl-xs-dev \
 	default-libmysqlclient-dev
 
+# Packages needed for debconf preseed selection of vpp - DK
+RUN apt-get update && apt-get install -y \
+	debconf-utils
+
 # Packages needed for keepalived
 RUN apt-get install -y \
     libipset-dev libnfnetlink-dev libnftnl-dev libnl-nf-3-dev libpopt-dev

--- a/package-build-iGOS/vpp/package.toml
+++ b/package-build-iGOS/vpp/package.toml
@@ -24,6 +24,10 @@ for patch in ../patches/vpp/*.patch; do
     git -c user.email=maintainers@vyos.net -c user.name=vyos am "$patch" || { echo "Failed to apply patch $patch"; exit 1; }
 done
 
+# this assumes debconf-utils is installed and preseeds the popup questions for iperf3 daemon and wireshark-common
+echo "iperf3 iperf3/start-daemon boolean true" | sudo debconf-set-selections
+echo "wireshark-common wireshark-common/install-setuid boolean true" | sudo debconf-set-selections
+
 make UNATTENDED=yes install-dep
 make pkg-deb
 cp build-root/*.deb ../


### PR DESCRIPTION
Add debconf-utils to container so we can preseed packages like VPP that asks the user for input.  To figure out what the preseed options are, build or install the package inside the container and answer all the questions you want, then after the build/install, get all the debconf options that you can pre-seed using debconf-get-selections | grep <option>.  You can set the debconf preseed option while build by echo "<pre seed option from the grep above> | sudo debconf-set-selections 