### PR TITLE
B12006:9999 - change generic and all product/model default config for change in syslog node name global->local as changed in T6989

### DIFF
--- a/package-build-iGOS/vyos-1x/config.boot.default.igos
+++ b/package-build-iGOS/vyos-1x/config.boot.default.igos
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/package-build-iGOS/vyos-1x/config.boot.default.vyos
+++ b/package-build-iGOS/vyos-1x/config.boot.default.vyos
@@ -41,7 +41,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-1000
+++ b/updates/model-info/default-config/config-IOLAN-1000
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2A00
+++ b/updates/model-info/default-config/config-IOLAN-2A00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2A01
+++ b/updates/model-info/default-config/config-IOLAN-2A01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2B00
+++ b/updates/model-info/default-config/config-IOLAN-2B00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2B01
+++ b/updates/model-info/default-config/config-IOLAN-2B01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2C00
+++ b/updates/model-info/default-config/config-IOLAN-2C00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2C01
+++ b/updates/model-info/default-config/config-IOLAN-2C01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2D00
+++ b/updates/model-info/default-config/config-IOLAN-2D00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2D01
+++ b/updates/model-info/default-config/config-IOLAN-2D01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2E00
+++ b/updates/model-info/default-config/config-IOLAN-2E00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2E01
+++ b/updates/model-info/default-config/config-IOLAN-2E01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2F00
+++ b/updates/model-info/default-config/config-IOLAN-2F00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-2F01
+++ b/updates/model-info/default-config/config-IOLAN-2F01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-3000
+++ b/updates/model-info/default-config/config-IOLAN-3000
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-3001
+++ b/updates/model-info/default-config/config-IOLAN-3001
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4A00
+++ b/updates/model-info/default-config/config-IOLAN-4A00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4A01
+++ b/updates/model-info/default-config/config-IOLAN-4A01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4B00
+++ b/updates/model-info/default-config/config-IOLAN-4B00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4B01
+++ b/updates/model-info/default-config/config-IOLAN-4B01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4C00
+++ b/updates/model-info/default-config/config-IOLAN-4C00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4C01
+++ b/updates/model-info/default-config/config-IOLAN-4C01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4D00
+++ b/updates/model-info/default-config/config-IOLAN-4D00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4D01
+++ b/updates/model-info/default-config/config-IOLAN-4D01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4E00
+++ b/updates/model-info/default-config/config-IOLAN-4E00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4E01
+++ b/updates/model-info/default-config/config-IOLAN-4E01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4F00
+++ b/updates/model-info/default-config/config-IOLAN-4F00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4F01
+++ b/updates/model-info/default-config/config-IOLAN-4F01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4G00
+++ b/updates/model-info/default-config/config-IOLAN-4G00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4G01
+++ b/updates/model-info/default-config/config-IOLAN-4G01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4H00
+++ b/updates/model-info/default-config/config-IOLAN-4H00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IOLAN-4H01
+++ b/updates/model-info/default-config/config-IOLAN-4H01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IRG-1000
+++ b/updates/model-info/default-config/config-IRG-1000
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IRG-1A00
+++ b/updates/model-info/default-config/config-IRG-1A00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IRG-1B00
+++ b/updates/model-info/default-config/config-IRG-1B00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IRG-2000
+++ b/updates/model-info/default-config/config-IRG-2000
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IRG-2001
+++ b/updates/model-info/default-config/config-IRG-2001
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IRG-2A00
+++ b/updates/model-info/default-config/config-IRG-2A00
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IRG-2A01
+++ b/updates/model-info/default-config/config-IRG-2A01
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IRG-3000
+++ b/updates/model-info/default-config/config-IRG-3000
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IRG-3001
+++ b/updates/model-info/default-config/config-IRG-3001
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IT-1000
+++ b/updates/model-info/default-config/config-IT-1000
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IT-1001
+++ b/updates/model-info/default-config/config-IT-1001
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IT-2000
+++ b/updates/model-info/default-config/config-IT-2000
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }

--- a/updates/model-info/default-config/config-IT-2001
+++ b/updates/model-info/default-config/config-IT-2001
@@ -44,7 +44,7 @@ system {
         }
     }
     syslog {
-        global {
+        local {
             facility all {
                 level "info"
             }


### PR DESCRIPTION
Fix for rsyslogd constantly being relaunched with error.  Breakage occurred in Feb 3, 202  with T6989 from upstream where syslog  node was changed from "global" to "local".  Due to us crafting our config.boot.default files specific to a product/model, we need to review the final config.boot.default that the upstream uses and compare to ours under nexus-build/package-build-iGOS.vyos-1x