### PR TITLE
live-config build-time emulation.

### DIFF
--- a/build_iGOS_TMDS64EVM_fs.sh
+++ b/build_iGOS_TMDS64EVM_fs.sh
@@ -183,7 +183,7 @@ if [ ! -f "$BLT" ]; then
     export VYOS1X_REPO_URL=https://github.com/psleng/vyos-1x
     export VYOS1X_REPO_BRANCH=psl-master
     sudo --preserve-env=VYOS1X_REPO_URL,VYOS1X_REPO_BRANCH \
-		./build-vyos-image $BUILDFLAVOUR --architecture $ARCH --build-by "psleng@perle.com"
+        ./build-vyos-image $BUILDFLAVOUR --architecture $ARCH --build-by "psleng@perle.com"
     cd -
     touch "$BLT" # build success
 else
@@ -233,23 +233,20 @@ if [ ! -f "$BLT" ]; then
     sudo cp -R $FS/usr/lib/linux-image*/ti $FS/boot/dtb
 
     echo "=== I: $0: $TSK: Almost done; performing fs fixups"
+    # For debugging: stash the unsullied rootfs for later diffing
+    #test -d $FS.pristine || { echo HACK; sudo cp -pr $FS $FS.pristine; }
 
-    # replace console ttyS0 with ours at ttyS3 and add one more device ttyS2
-    # sudo sed -i 's/ttyS0/ttyS3/' $FS/usr/share/vyos/config.boot.default
-    # sudo sed -i '/console.*$/a \        device ttyS2 {\n\t    speed \"115200\"\n\t}' $FS/usr/share/vyos/config.boot.default
+    # Run the debian-live config scripts now within chroot of the fs.
+    # This is a bit bogus but saves bootup time of the eventual product.
+    sudo cp -p updates/run-live-config $FS/usr/lib/live/
+    sudo chroot $FS bash -c usr/lib/live/run-live-config
 
-    # copy the perle-init once service that mounts /config to /opt/vyatta.etc.config and installs the snakeoil cert if missing
+    # Copy the perle-init once service that performs /lib/live/boot/* tasks
     sudo cp updates/perle-init.service $FS/lib/systemd/system
     sudo ln -s /lib/systemd/system/perle-init.service $FS/etc/systemd/system/multi-user.target.wants/perle-init.service
     sudo cp updates/perle-init.sh $FS/usr/bin
     sudo cp -rf updates/model-info $FS/usr/share/vyos/
     sudo cp -rf updates/product.env $FS/etc/
-
-    # Generate a default locale (stops warnings from perl)
-    if [ ! -f $FS/usr/lib/locale/locale-archive ]; then
-        echo "en_US.UTF-8 UTF-8" | sudo tee -a $FS/etc/locale.gen > /dev/null
-        sudo chroot $FS locale-gen
-    fi
 
     # Decompress the vmlinuz (symlink to the real thing) into Image
     gunzip < $FS/boot/vmlinuz | sudo sh -c "cat > $FS/boot/Image"

--- a/updates/perle-init.sh
+++ b/updates/perle-init.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
-#
+
+### /lib/live/boot/* functionality
+
+# === Corresponds to lib/live/boot/9990-vyos.sh
+# create the /config mount point to /opt/vyatta/etc/config and set uid/group root:vyattacfg
+	chown root:vyattacfg /config
+	mount --bind /opt/vyatta/etc/config /config
+#	chown root:vyattacfg /config
+
+
+### /lib/live/config/* functionality
+# None of these should be needed if updates/run-live-config
+# is run during the build.
+
+# === Corresponds to lib/live/config/1090-ssl-cert
 # check if snakeoil private and public keys exist, and create if either is absent
 #
 	if [ ! -e /etc/ssl/certs/ssl-cert-snakeoil.pem ] || [ ! -e /etc/ssl/private/ssl-cert-snakeoil.key ]
@@ -9,10 +23,4 @@
 
 	# Creating state file
 	touch /var/lib/live/config/ssl-cert
-#
-# create the /config mount point to /opt/vyatta/etc/config and set uid/group root:vyattacfg
-#
-	chown root:vyattacfg /config
-	mount --bind /opt/vyatta/etc/config /config
-#	chown root:vyattacfg /config
 

--- a/updates/run-live-config
+++ b/updates/run-live-config
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Runs the live-build config scripts during build time.
+# The intent is to keep bootup time as short as possible.
+#
+# NOTE: This assumes that boot=live is NOT set in /proc/cmdline
+# of the target device.  If it *is*, the /usr/lib/live/config/*
+# scripts will run on bootup anyway (live-config.service)
+#
+
+cd /usr/lib/live
+PROG=$(basename $0)
+HOSTNAME=$(hostname)
+LOG=$PROG.log
+
+echo "=== $0 on host $HOSTNAME at $(date)" | tee $LOG
+
+# Create a bogus /proc/cmdline with what scripts might expect
+CMDLINEPATH=/proc/cmdline
+if [ ! -f "$CMDLINEPATH" ]; then
+	cat > $CMDLINEPATH <<-%
+	noautologin boot=live
+	%
+fi
+
+# Create a bogus /etc/hosts with the current hostname for make-ssl-cert
+if ! grep -q "$HOSTNAME" /etc/hosts; then
+	ohosts=/etc/hosts.dist
+	mv /etc/hosts $ohosts
+	echo 127.0.0.1 localhost | tee /etc/hosts
+	echo 127.0.1.1 $(hostname) | tee -a /etc/hosts
+fi
+
+# Run all the scripts
+cd config
+for component in *
+do
+	test -x $component || continue
+	echo === Running $component
+	bash -x ./$component || {
+		echo WARNING: $component returned $?
+	}
+done 2>&1 | tee -a ../$LOG
+
+# Clean up the bogus stuff
+rm -f $CMDLINEPATH
+test -f $ohosts && mv $ohosts /etc/hosts
+
+# vim: set noet


### PR DESCRIPTION
Instead of passing in "boot=live" to the kernel command line
which effectively makes /lib/live/config/* scripts run via
the live-config.service , do it at buildtime via chroot to
avoid slowing down the boot.

Beware that /lib/live/boot/* scripts, which are supposed to run early
and really do need a running system, are still not handled so we still          need updates/perle-init.sh .  It just does not need to fake up the
/lib/live/config/* actions.

Note that VyOS itself relies on seeing the pattern "BOOT_IMAGE=/boot/"
at the start of /proc/cmdline in order to adjust itself for "image install"
behaviour (which is ultimately also what we want).  However, their code
assumes the boot was via grub, so if it was not (normal for our arm64 boards)
it breaks bootup.  This will have to be readdressed later.
