### PR TITLE
ssh support for rundocker.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ endef
 
 # Build the arm64 VyOS building container image
 $(CONT_TARG):
-	@echo ### Making build container image ($@)'
+	@echo '### Making build container image ($@)'
 	./buildvyoscontainer.sh
 	@touch $@
 

--- a/bin/checkDockerImageUptodate.py
+++ b/bin/checkDockerImageUptodate.py
@@ -5,7 +5,7 @@ import sys
 from subprocess import run
 
 
-def main(img: str, dockerfile: str) -> int:
+def main(img: str, dockerfile: str, entrypoint: str) -> int:
     '''
     Compare docker image "img" to dockerfile "dockerfile".
     Returns 0 if the image is newer than the dockerfile, else 1.
@@ -24,27 +24,27 @@ def main(img: str, dockerfile: str) -> int:
         imgst = time.strptime(imgdate, '%Y-%m-%d %H:%M:%S %z %Z')
         img_mtime = time.mktime(imgst)
 
-    # Get timestamp of the Dockerfile-*
-    df_mtime = Path(dockerfile).stat().st_mtime
+    # Check paths up to date compared to image
+    for f in (dockerfile, entrypoint):
+        # Get timestamp
+        df_mtime = Path(f).stat().st_mtime
+        if (img_mtime - df_mtime) > 0:
+            needs = "does NOT need"
+            ret = 0
+        else:
+            print(f'{f} is newer than docker image')
+            needs = "DOES need"
+            ret = 1
 
-    # print(time.ctime(img_mtime))
-    # print(time.ctime(df_mtime))
-    # print(img_mtime - df_mtime)
-
-    if (img_mtime - df_mtime) > 0:
-        needs = "does NOT need"
-        ret = 0
-    else:
-        needs = "DOES need"
-        ret = 1
     print(f'docker image {needs} to be rebuilt')
 
     return ret
 
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print(f'Usage {sys.argv[0]} imgname Dockerfile', file=sys.stderr)
+    if len(sys.argv) != 4:
+        print(f'Usage: {sys.argv[0]} imgname Dockerfile entrypoint.sh',
+              file=sys.stderr)
         exit(1)
 
-    exit(main(sys.argv[1], sys.argv[2]))
+    exit(main(sys.argv[1], sys.argv[2], sys.argv[3]))

--- a/buildvyoscontainer.sh
+++ b/buildvyoscontainer.sh
@@ -16,10 +16,16 @@ if [ "$BUILDTARG" != "x86_64" ]; then
     fi
 fi
 
+if [ ! -d vyos-build ]; then
+    echo "I: Cloning vyos-build"
+    git clone -b psl-master --single-branch https://github.com/psleng/vyos-build
+fi
+
 if docker image inspect $IMGNAME > /dev/null 2>&1; then
     # Docker image exists, but is it up to date?
     P=$(basename $0)
-    if $ROOTDIR/bin/checkDockerImageUptodate.py $IMGNAME Dockerfile-$(arch)
+    if $ROOTDIR/bin/checkDockerImageUptodate.py $IMGNAME \
+            Dockerfile-$ARCH vyos-build/docker/entrypoint.sh
     then
         echo "$P: $IMGNAME exists and is up to date; skipping rebuild."
         echo "$P: To force a rebuild type:"
@@ -32,10 +38,6 @@ if docker image inspect $IMGNAME > /dev/null 2>&1; then
     fi
 fi
 
-if [ ! -d vyos-build ]; then
-    echo "I: Cloning vyos-build"
-    git clone -b psl-master --single-branch https://github.com/psleng/vyos-build
-fi
 cd vyos-build
 
 DF=${ROOTDIR}/Dockerfile-$ARCH

--- a/rundocker.sh
+++ b/rundocker.sh
@@ -13,13 +13,22 @@ else
     fi
 fi
 
+# Make invoking user's .gitconfig available
 GITCONFIG=$HOME/.gitconfig
 if [ -f $GITCONFIG ]; then
     GITMNT="-v $GITCONFIG:/etc/gitconfig"
 else
     echo "$0: WARNING: \"$GITCONFIG\" does not exist." >&2
-    echo "$0: Copy your personal ~/.gitconfig to that location" >&2
     GITMNT=''
+fi
+
+# Make invoking user's .ssh/ available
+SSH=$HOME/.ssh
+if [ -d $SSH ]; then
+    SSHMNT="-v $SSH:/etc/.ssh"
+else
+    echo "$0: WARNING: \"$SSH\" does not exist." >&2
+    SSHMNT=''
 fi
 
 . ./.defs.mk
@@ -38,5 +47,5 @@ docker run --rm $DFLAGS \
   --privileged --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
   -h vyos-build \
   -v $(pwd):/vyos -v /dev:/dev -v /etc/fstab:/etc/fstab \
-  $GITMNT -w /vyos \
+  $GITMNT $SSHMNT -w /vyos \
   vyos/vyos-build:$TAG "$@"


### PR DESCRIPTION
This will supply the ~/.ssh credentials of the user invoking
rundocker.sh to the container process.

This is so that we can start cloning https://github.com/Perle-Systems-Limited/
repositories in the build.  This is useful for proprietary code which
we do not want public via https://github.com/psleng .

NOTE: Needs commit 0f083a05538f820487670a12375cd57ac68fdf52
from vyos-build to work.  The docker image needs to be rebuilt
with that commit checked out.
