### PR TITLE
mods to support optee_ftpm, and tpm2 support in openssl

### DIFF
--- a/updates/arm64fs.toml
+++ b/updates/arm64fs.toml
@@ -9,6 +9,7 @@ packages = [
   "qemu-guest-agent",
   "python3-pip",
   "python3-venv",
+  "tpm2-openssl",
   # "vyos-xe-guest-utilities",
 ]
 


### PR DESCRIPTION
We need the tpm2-openssl package which contains the tpm2.so  provider that openssl 3.0.x will need to use /dev/tpm0 resources which will be managed with by the kernel's tpm_ftpm_tee driver <-> tee-supplicant <-> optee_ftpm (TPM2) <-> REE FS in optee_os