### PR TITLE
Add default operator-group super-operator, that will be used for supporting the original operator+ user type

### DIFF
--- a/package-build-iGOS/vyos-1x/config.boot.default.igos
+++ b/package-build-iGOS/vyos-1x/config.boot.default.igos
@@ -36,6 +36,16 @@ system {
     }
     host-name iGuard
     login {
+        operator-group default {
+            command-policy {
+                allow "*"
+            }
+        }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/package-build-iGOS/vyos-1x/config.boot.default.vyos
+++ b/package-build-iGOS/vyos-1x/config.boot.default.vyos
@@ -33,6 +33,16 @@ system {
     }
     host-name "vyos"
     login {
+        operator-group default {
+            command-policy {
+                allow "*"
+            }
+        }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user vyos {
             authentication {
                 encrypted-password "$6$QxPS.uk6mfo$9QBSo8u1FkH16gMyAVhus6fU3LOzvLR9Z9.82m3tiHFAxTtIkhaZSWssSgzt4v4dGAL8rhVQxTg0oAG9/q11h/"

--- a/updates/model-info/default-config/config-IOLAN-1000
+++ b/updates/model-info/default-config/config-IOLAN-1000
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2A00
+++ b/updates/model-info/default-config/config-IOLAN-2A00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2A01
+++ b/updates/model-info/default-config/config-IOLAN-2A01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2B00
+++ b/updates/model-info/default-config/config-IOLAN-2B00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2B01
+++ b/updates/model-info/default-config/config-IOLAN-2B01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2C00
+++ b/updates/model-info/default-config/config-IOLAN-2C00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2C01
+++ b/updates/model-info/default-config/config-IOLAN-2C01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2D00
+++ b/updates/model-info/default-config/config-IOLAN-2D00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2D01
+++ b/updates/model-info/default-config/config-IOLAN-2D01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2E00
+++ b/updates/model-info/default-config/config-IOLAN-2E00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2E01
+++ b/updates/model-info/default-config/config-IOLAN-2E01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2F00
+++ b/updates/model-info/default-config/config-IOLAN-2F00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-2F01
+++ b/updates/model-info/default-config/config-IOLAN-2F01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-3000
+++ b/updates/model-info/default-config/config-IOLAN-3000
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-3001
+++ b/updates/model-info/default-config/config-IOLAN-3001
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4A00
+++ b/updates/model-info/default-config/config-IOLAN-4A00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4A01
+++ b/updates/model-info/default-config/config-IOLAN-4A01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4B00
+++ b/updates/model-info/default-config/config-IOLAN-4B00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4B01
+++ b/updates/model-info/default-config/config-IOLAN-4B01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4C00
+++ b/updates/model-info/default-config/config-IOLAN-4C00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4C01
+++ b/updates/model-info/default-config/config-IOLAN-4C01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4D00
+++ b/updates/model-info/default-config/config-IOLAN-4D00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4D01
+++ b/updates/model-info/default-config/config-IOLAN-4D01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4E00
+++ b/updates/model-info/default-config/config-IOLAN-4E00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4E01
+++ b/updates/model-info/default-config/config-IOLAN-4E01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4F00
+++ b/updates/model-info/default-config/config-IOLAN-4F00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4F01
+++ b/updates/model-info/default-config/config-IOLAN-4F01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4G00
+++ b/updates/model-info/default-config/config-IOLAN-4G00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4G01
+++ b/updates/model-info/default-config/config-IOLAN-4G01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4H00
+++ b/updates/model-info/default-config/config-IOLAN-4H00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IOLAN-4H01
+++ b/updates/model-info/default-config/config-IOLAN-4H01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IRG-1000
+++ b/updates/model-info/default-config/config-IRG-1000
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IRG-1A00
+++ b/updates/model-info/default-config/config-IRG-1A00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IRG-1B00
+++ b/updates/model-info/default-config/config-IRG-1B00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IRG-2000
+++ b/updates/model-info/default-config/config-IRG-2000
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IRG-2001
+++ b/updates/model-info/default-config/config-IRG-2001
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IRG-2A00
+++ b/updates/model-info/default-config/config-IRG-2A00
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IRG-2A01
+++ b/updates/model-info/default-config/config-IRG-2A01
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IRG-3000
+++ b/updates/model-info/default-config/config-IRG-3000
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IRG-3001
+++ b/updates/model-info/default-config/config-IRG-3001
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IT-1000
+++ b/updates/model-info/default-config/config-IT-1000
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IT-1001
+++ b/updates/model-info/default-config/config-IT-1001
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IT-2000
+++ b/updates/model-info/default-config/config-IT-2000
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'

--- a/updates/model-info/default-config/config-IT-2001
+++ b/updates/model-info/default-config/config-IT-2001
@@ -41,6 +41,11 @@ system {
                 allow "*"
             }
         }
+        operator-group super-operator {
+            command-policy {
+                allow "*"
+            }
+        }
         user igos {
             authentication {
                 encrypted-password '$6$rounds=656000$BQclSwEm9YgVuKw.$mugiIKLMpB/rS2p2iaed7Y/PSJBhe117lmkbBnMfEi9A2KjogKsvn9eSfEEeor1J0KRk8gluPhCdstvc7o5yY.'


### PR DESCRIPTION
Last upstream merge removed our "set system login user type administrator | operator | operator+" in favour of using vyos introduction of operator-group and allowing the user to use the "default" group, or none (implies administrator), or create a custom operator-group which has allowed vyos op-mode commands.  At this time, the feature is not complete and does not work.  We introduce a new default "super-operator" group that will be used to replace our concept of operator+ that allows an resetting any users' password as the only admin type function.  Each model default config file will now have the super-operator group.  The logic to check the new way of configuring operator+ will be modified in a future commit. 