### PR TITLE
Add branding/fixups to iso contents and re-generating .iso that can b…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /debian-repos
 /drivers
 /images
+/iso-images
 /logs
 /nohup.out
 /psleng.github.io

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ UBOOT_TARG    = .uboot.built
 FS_TARG       = .filesystem.built
 IMAGE_TARG    = .image.built
 
+DATECODE = $(shell date +%Y%m%d%H%M%S00)
+
 help:
 	@echo First select a build type.  Valid types are:
 	@echo
@@ -41,6 +43,8 @@ help:
 	@echo 'make containerclean # remove build container image.'
 	@echo
 	@echo 'make sdcard         # flash sdcard with the built image'
+	@echo 'make sdcard-squashfs# flash sdcard with squash image in ./iso-images<buildtype/stage-iso'
+	@echo 'make live-iso       # create iso in ./iso-images/<buildtype>'
 	@echo 'make dfuimg         # create DFU images to \"dfu-images\" folder'
 	@echo
 	@if [ -s "$(DEFS)" ]; then \
@@ -93,7 +97,7 @@ else
 	IMGTAG := latest
 endif
 
-.PHONY: help all sdcard status clean mostlyclean targ-ti-am64x targ-ti-j7200 targ-x86 containerclean spotless
+.PHONY: help all sdcard sdcard-squashfs live-iso status clean mostlyclean targ-ti-am64x targ-ti-j7200 targ-x86 containerclean spotless
 
 all: $(DEFS) $(IMAGE_TARG)
 
@@ -143,17 +147,50 @@ else
 	@ls -l images/$(BUILDTYPE)/tisdk*.squashfs
 	@echo '### Making uSDcard image COMPLETED'
 	@echo '### Type "bin/buildlog" to check for errors'
-	@echo '### Type "make sdcard" to write to an uSD card'
+	@echo '### Type "make sdcard" to write bootloader and flat rootfs to an uSD card'
+	@echo '### Type "make sdcard-squashfs" to write bootloader and squashed rootfs to an uSD card'
+	@echo '### Type "make live-iso" to create a live iso under /iso_images'
 	@touch $@
 endif
 
-# Write to a uSDcard.
+# Write bootloader and flat rootfs to a uSDcard.
 sdcard: $(IMAGE_TARG)
 ifeq ($(BUILDTARG),x86_64)
 	@echo "### Skipping $@ because BUILDTARG=$(BUILDTARG)"
 else
 	@echo '### Making $@'
 	sudo ti-bdebstrap/create-sdcardiGOS.sh $(BUILDTYPE)
+	@echo '### Making $@ COMPLETED'
+endif
+
+# Write bootloader and squashfs rootfs to a uSDcard.
+sdcard-squashfs: $(IMAGE_TARG)
+ifeq ($(BUILDTARG),x86_64)
+	@echo "### Skipping $@ because BUILDTARG=$(BUILDTARG)"
+else
+	@echo '### Making $@'
+	sudo ti-bdebstrap/create-sdcardiGOS.sh $(BUILDTYPE) squashfs
+	@echo '### Making $@ COMPLETED'
+endif
+
+# Create a live ISO from the iso_image/$(BUILDTYPE)/stage_iso/*
+live-iso: $(IMAGE_TARG)
+ifeq ($(BUILDTARG),x86_64)
+	@echo "### Skipping $@ because BUILDTARG=$(BUILDTARG)"
+else
+	@echo '### Making $@'
+	@command -v xorriso >/dev/null 2>&1 || { \
+		echo "Error: xorriso is not installed."; \
+		echo "Please install it by running: sudo apt install xorriso"; \
+		exit 1; \
+	}
+	# create an iso with the igos updates using the same iso attributes
+	sudo xorriso -as mkisofs -R -r -J -joliet-long -l -cache-inodes -iso-level 3 -A "iGOS" \
+  -p "live-build ${DATECODE}; https://salsa.debian.org/live-team/live-build" \
+  -publisher "psleng@perle.com" -V "iGOS" --modification-date="${DATECODE}" \
+  -e boot/grub/efi.img -no-emul-boot -isohybrid-gpt-basdat -isohybrid-apm-hfsplus \
+  -o iso-images/$(BUILDTYPE)/"igos-live-${DATECODE}-arm64.iso" iso-images/$(BUILDTYPE)/stage_iso
+
 	@echo '### Making $@ COMPLETED'
 endif
 

--- a/build_iGOS_TMDS64EVM_fs.sh
+++ b/build_iGOS_TMDS64EVM_fs.sh
@@ -240,13 +240,14 @@ if [ ! -f "$BLT" ]; then
     ISOLOOP=$(sudo losetup --show -f ${LIVE_IMAGE_ISO})
     echo "Mounting iso on loopback: ${ISOLOOP}"
 
+    ISO_DIR=$ROOTDIR/build/tmp
     sudo rm -rf build
-    sudo mkdir -p build/tmp/
-    sudo mount -o ro ${ISOLOOP} build/tmp/
+    sudo mkdir -p  $ISO_DIR
+    sudo mount -o ro ${ISOLOOP} $ISO_DIR
     FS=$ROOTDIR/build/fs
-    sudo unsquashfs -d $FS build/tmp/live/filesystem.squashfs
+    sudo unsquashfs -d $FS $ISO_DIR/live/filesystem.squashfs
 
-    #rm -rf $FS/boot/grub
+    # -rm -rf $FS/boot/grub
     sudo mkdir $FS/boot/dtb
     sudo cp -R $FS/usr/lib/linux-image*/ti $FS/boot/dtb
 
@@ -266,6 +267,76 @@ if [ ! -f "$BLT" ]; then
     sudo cp updates/perle-init.sh $FS/usr/bin
     sudo cp -rf updates/model-info $FS/usr/share/vyos/
     sudo cp -rf updates/product.env $FS/etc/
+
+    # !!!! end of core rootfs fixups - do not add further fixups after this point
+    # unless it is sdcard or mmc rootfs specific
+
+    # START - make a copy of the ISO for squashfs image type
+    STAGE_ISO=$ROOTDIR/build/stage_iso
+    ISOPATH_BUILD=$ROOTDIR/iso-images/$BUILDTYPE
+
+    # create directory for staging the squashfs version of the image
+    sudo rm -rf $STAGE_ISO
+    sudo mkdir -p $STAGE_ISO
+    sudo chmod u+w $STAGE_ISO
+
+    # copy entire ISO to staging area,  preserving all attrs, hidden, symlinks
+    # and remove original filesystem.squashfs in prep for updated one
+    sudo cp -a $ISO_DIR/. $STAGE_ISO/
+    sudo rm -f $STAGE_ISO/live/filesystem.squashfs
+
+    # copy all cumulative fixups in flat rootfs preserving all attrs, hidden, symlinks
+    # to the staging filesystem directory
+
+    # copy the dtbs from built location to /boot/dtb for uboot to access this is different
+    # than copying it WITHIN the /boot/dtb in the LINUX rootfs that install_image.py needs
+    # to copy to another image's /boot/dtb that uboot needs to access
+    sudo mkdir $STAGE_ISO/boot/dtb
+    sudo cp -R $FS/usr/lib/linux-image*/ti $STAGE_ISO/boot/dtb
+
+    SQUASHFILE=$STAGE_ISO/live/filesystem.squashfs
+    # now we need to squash everthing back to the /live/filesystem.squashfs and zap the rest of the rootfs
+    # except for what was in the original ISO
+    sudo mksquashfs $FS $SQUASHFILE -comp xz -b 262144 -always-use-fragments -noappend
+
+    # we need to replace the sha256 checksum, in the live/sha256sum.txt as the last thing, otherwise
+    # the "add system image <file.iso> will fail on checksum verificatiom
+    SHA256TXTFILE=$STAGE_ISO/sha256sum.txt
+    RELSQUASHFILE=./live/filesystem.squashfs
+
+    # make the sha256sum.txt writeable
+    sudo chmod u+w $SHA256TXTFILE
+
+    # Calculate new hash
+    NEWHASH=$(sha256sum "$SQUASHFILE" | awk '{print $1}')
+
+    # Update the entry inside sha256sum.txt
+    sudo sed -i "s|^[0-9a-f]\{64\}  $RELSQUASHFILE|$NEWHASH $RELSQUASHFILE|" "$SHA256TXTFILE"
+
+    # make the sha256sum.txt non-writeable
+    sudo chmod u-w $SHA256TXTFILE
+
+    # Extract the kernel version from the initrd.img-* file (assuming it follows the pattern)
+    KERNEL_VER=$(ls ${STAGE_ISO}/live/initrd.img-* | sed 's/.*initrd.img-\(.*\)/\1/' | head -n 1)
+
+    echo "Creating initrd.img-${KERNEL_VER} and vmlinuz-${KERNEL_VER} symlinks"
+
+    # Create the symlinks
+    sudo ln -sf initrd.img-${KERNEL_VER} ${STAGE_ISO}/live/initrd.img
+    sudo ln -sf vmlinuz-${KERNEL_VER} ${STAGE_ISO}/live/vmlinuz
+
+    # cleanup the staging filesystem directory
+    sudo rm -rf $ISOPATH_BUILD/stage_iso
+    sudo mkdir -p $ISOPATH_BUILD/stage_iso
+    sudo cp -a $STAGE_ISO/. $ISOPATH_BUILD/stage_iso/
+    sudo rm -rf $STAGE_ISO
+
+    # END - make a copy of the rootfs for non-sdcard image
+
+    # housekeeping - remove vyos-build/build/vyos*.iso
+    sudo rm -f vyos-build/build/vyos*.iso
+
+    # flat rootfs sdcard build continues below
 
     # Decompress the vmlinuz (symlink to the real thing) into Image
     gunzip < $FS/boot/vmlinuz | sudo sh -c "cat > $FS/boot/Image"


### PR DESCRIPTION
Add branding/fixups to iso contents and re-generating .iso, updating the sha256sum.txt (validation) that can be installed using 'install image' and add system image <file.iso>' op-mode commands.  The iso type files images are found per buildtype under

nexus-build/iso-images/<buildtype>/igos-*.iso 
nexus-build/iso-images/<buildtype>/stage_iso/* 