### PR TITLE
Update default configuration files for configuration of vyos-http-api

### DIFF
--- a/package-build-iGOS/vyos-1x/config.boot.default.igos
+++ b/package-build-iGOS/vyos-1x/config.boot.default.igos
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-1000
+++ b/updates/model-info/default-config/config-IOLAN-1000
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2A00
+++ b/updates/model-info/default-config/config-IOLAN-2A00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2A01
+++ b/updates/model-info/default-config/config-IOLAN-2A01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2B00
+++ b/updates/model-info/default-config/config-IOLAN-2B00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2B01
+++ b/updates/model-info/default-config/config-IOLAN-2B01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2C00
+++ b/updates/model-info/default-config/config-IOLAN-2C00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2C01
+++ b/updates/model-info/default-config/config-IOLAN-2C01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2D00
+++ b/updates/model-info/default-config/config-IOLAN-2D00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2D01
+++ b/updates/model-info/default-config/config-IOLAN-2D01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2E00
+++ b/updates/model-info/default-config/config-IOLAN-2E00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2E01
+++ b/updates/model-info/default-config/config-IOLAN-2E01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2F00
+++ b/updates/model-info/default-config/config-IOLAN-2F00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-2F01
+++ b/updates/model-info/default-config/config-IOLAN-2F01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-3000
+++ b/updates/model-info/default-config/config-IOLAN-3000
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-3001
+++ b/updates/model-info/default-config/config-IOLAN-3001
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4A00
+++ b/updates/model-info/default-config/config-IOLAN-4A00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4A01
+++ b/updates/model-info/default-config/config-IOLAN-4A01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4B00
+++ b/updates/model-info/default-config/config-IOLAN-4B00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4B01
+++ b/updates/model-info/default-config/config-IOLAN-4B01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4C00
+++ b/updates/model-info/default-config/config-IOLAN-4C00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4C01
+++ b/updates/model-info/default-config/config-IOLAN-4C01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4D00
+++ b/updates/model-info/default-config/config-IOLAN-4D00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4D01
+++ b/updates/model-info/default-config/config-IOLAN-4D01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4E00
+++ b/updates/model-info/default-config/config-IOLAN-4E00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4E01
+++ b/updates/model-info/default-config/config-IOLAN-4E01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4F00
+++ b/updates/model-info/default-config/config-IOLAN-4F00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4F01
+++ b/updates/model-info/default-config/config-IOLAN-4F01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4G00
+++ b/updates/model-info/default-config/config-IOLAN-4G00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4G01
+++ b/updates/model-info/default-config/config-IOLAN-4G01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4H00
+++ b/updates/model-info/default-config/config-IOLAN-4H00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IOLAN-4H01
+++ b/updates/model-info/default-config/config-IOLAN-4H01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IRG-1000
+++ b/updates/model-info/default-config/config-IRG-1000
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IRG-1A00
+++ b/updates/model-info/default-config/config-IRG-1A00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IRG-1B00
+++ b/updates/model-info/default-config/config-IRG-1B00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IRG-2000
+++ b/updates/model-info/default-config/config-IRG-2000
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IRG-2001
+++ b/updates/model-info/default-config/config-IRG-2001
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IRG-2A00
+++ b/updates/model-info/default-config/config-IRG-2A00
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IRG-2A01
+++ b/updates/model-info/default-config/config-IRG-2A01
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IRG-3000
+++ b/updates/model-info/default-config/config-IRG-3000
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IRG-3001
+++ b/updates/model-info/default-config/config-IRG-3001
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IT-1000
+++ b/updates/model-info/default-config/config-IT-1000
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IT-1001
+++ b/updates/model-info/default-config/config-IT-1001
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IT-2000
+++ b/updates/model-info/default-config/config-IT-2000
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"

--- a/updates/model-info/default-config/config-IT-2001
+++ b/updates/model-info/default-config/config-IT-2001
@@ -3,6 +3,23 @@ interfaces {
     }
 }
 service {
+    https {
+        api {
+            graphql {
+                authentication {
+                    type key
+                }
+            }
+            keys {
+                id myid {
+                    key mykey
+                }
+            }
+            rest {
+            }
+        }
+        port 443
+    }
     ntp {
         allow-client {
             address "127.0.0.0/8"


### PR DESCRIPTION
- Default configuration for vyos-http-api
- Preset key to access vyos-http-api (related to the change in vyos-1x to make vyos-http-api accept only requests from localhost 127.0.0.1)