### PR TITLE
Build emmc production image that will be uses to flash emmc parts during production.  It creates the same 3 partitions containing grub, and the grub config, factory and current firmware layout exactly like running vyos command 'install image'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ help:
 	@echo 'make sdcard-squashfs# flash sdcard with squash image in ./iso-images<buildtype/stage-iso'
 #	@echo 'make live-iso       # create iso in ./iso-images/<buildtype>'
 	@echo 'make dfuimg         # create DFU images to \"dfu-images\" folder'
+	@echo 'make prod-image     # create 16G emmc and boot images in ./iso-images/<buildtype>'
 	@echo
 	@if [ -s "$(DEFS)" ]; then \
 	    echo "The current build settings ($(DEFS)) are:"; \
@@ -203,6 +204,7 @@ else
 	@echo '### Type "make sdcard" to write bootloader and flat rootfs to an uSD card'
 	@echo '### Type "make sdcard-squashfs" to write bootloader + squashed rootfs to uSD card'
 #	@echo '### Type "make live-iso" to create a live iso under /iso_images'
+	@echo '### Type "make prod-image" to create 16G emmc and boot images in /iso-images'
 	@echo '################################################################################# '
 	@echo '#### '
 	@echo '######################################################## '
@@ -263,6 +265,16 @@ ifeq ($(BUILDTARG),x86_64)
 else
 	@echo '### Making $@'
 	@./build-dfu-image.sh
+	@echo '### Making $@ COMPLETED'
+endif
+
+# Create emmc and boot production .img files.
+prod-image: $(IMAGE_TARG)
+ifeq ($(BUILDTARG),x86_64)
+	@echo "### Skipping $@ because BUILDTARG=$(BUILDTARG)"
+else
+	@echo '### Making $@'
+	@./build_igos_prod_image.sh
 	@echo '### Making $@ COMPLETED'
 endif
 

--- a/build_igos_prod_image.sh
+++ b/build_igos_prod_image.sh
@@ -12,12 +12,20 @@ ISOPATH=$ROOTDIR/iso-images/$BUILDTYPE
 ISOPATH_STAGE=$ROOTDIR/iso-images/$BUILDTYPE/stage_iso
 IMAGEPATH=$ROOTDIR/images/$BUILDTYPE
 
+BOOT3OFFSET=0
+SPLOFFSET=0x800
+UBOOTOFFSET=0x1800
+BOOTIMGSIZE_MB=7
+
 if [[ "$BUILDTYPE" == "bookworm-am64xx-evm" ]]; then
     UENVFILE="$ROOTDIR/updates/uEnv/uEnv-am64x-evm.txt"
 elif [[ "$BUILDTYPE" == "bookworm-j7200-evm" ]]; then
     UENVFILE="$ROOTDIR/updates/uEnv/uEnv-j72x-evm.txt"
 else
     UENVFILE="$ROOTDIR/updates/uEnv/uEnv-iolan.txt"
+    SPLOFFSET=0x700
+    UBOOTOFFSET=0x1000
+    BOOTIMGSIZE_MB=4
 fi
 
 if [[ ! -d "$ISOPATH_STAGE" ]]; then
@@ -159,16 +167,16 @@ else
     echo "Unsquashing boot squash image $1 found in: $IMAGEPATH"
     sudo unsquashfs -f -d "$UBOOTWORK" "$1"
 
-    sudo dd if=/dev/zero of=$BOOTIMG bs=1M count=7    
+    sudo dd if=/dev/zero of=$BOOTIMG bs=1M count=$BOOTIMGSIZE_MB    
 
-    # tiboot3.bin @ 0x0
-    sudo dd if=$UBOOTWORK/tiboot3.bin of=$BOOTIMG bs=512 seek=0 conv=notrunc
+    # tiboot3.bin
+    sudo dd if=$UBOOTWORK/tiboot3.bin of=$BOOTIMG bs=512 seek=$BOOT3OFFSET conv=notrunc
 
-    # tispl.bin @ 0x800
-    sudo dd if=$UBOOTWORK/tispl.bin of=$BOOTIMG bs=512 seek=$((0x800)) conv=notrunc
+    # tispl.bin
+    sudo dd if=$UBOOTWORK/tispl.bin of=$BOOTIMG bs=512 seek=$(($SPLOFFSET)) conv=notrunc
 
-    # u-boot.img @ 0x1800
-    sudo dd if=$UBOOTWORK/u-boot.img of=$BOOTIMG bs=512 seek=$((0x1800)) conv=notrunc
+    # u-boot.img
+    sudo dd if=$UBOOTWORK/u-boot.img of=$BOOTIMG bs=512 seek=$(($UBOOTOFFSET)) conv=notrunc
 
     echo "==========================================================================="
     echo "Production boot image build complete: $BOOTIMG"

--- a/build_igos_prod_image.sh
+++ b/build_igos_prod_image.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -e
+
+ROOTDIR=$(pwd)
+
+. $ROOTDIR/.defs.mk
+
+ARCH=$(dpkg-architecture -qDEB_HOST_ARCH)
+DATECODE=$(date +%Y%m%d%H%M%S00)
+
+ISOPATH=$ROOTDIR/iso-images/$BUILDTYPE
+ISOPATH_STAGE=$ROOTDIR/iso-images/$BUILDTYPE/stage_iso
+IMAGEPATH=$ROOTDIR/images/$BUILDTYPE
+
+if [[ "$BUILDTYPE" == "bookworm-am64xx-evm" ]]; then
+    UENVFILE="$ROOTDIR/updates/uEnv/uEnv-am64x-evm.txt"
+elif [[ "$BUILDTYPE" == "bookworm-j7200-evm" ]]; then
+    UENVFILE="$ROOTDIR/updates/uEnv/uEnv-j72x-evm.txt"
+else
+    UENVFILE="$ROOTDIR/updates/uEnv/uEnv-iolan.txt"
+fi
+
+if [[ ! -d "$ISOPATH_STAGE" ]]; then
+    echo "Error: missing iso staging directory: $ISOPATH_STAGE"
+    exit 1
+fi
+
+IMG=$ROOTDIR/iso-images/$BUILDTYPE/igos-prod-${DATECODE}.img
+BOOTIMG=$ROOTDIR/iso-images/$BUILDTYPE/igos-boot-${DATECODE}.img
+SIZE=14G
+
+WORKDIR=$ISOPATH/prod-work
+ROOTFS=$WORKDIR/rootfs
+UBOOTWORK=$WORKDIR/boot
+MOUNT=$ROOTFS/mnt
+MOUNT_P2=$ROOTFS/mnt/p3/boot/efi
+MOUNT_P3=$ROOTFS/mnt/p3
+
+
+cleanup() {
+    echo "Cleaning up..."
+
+    sudo umount -lf "$ROOTFS/mnt/iso" 2>/dev/null || true
+    sudo umount -lf "$ROOTFS/dev" 2>/dev/null || true
+    sudo umount -lf "$ROOTFS/proc" 2>/dev/null || true
+    sudo umount -lf "$ROOTFS/sys" 2>/dev/null || true
+    sudo umount -lf "$ROOTFS/run" 2>/dev/null || true
+    sudo umount -lf "$MOUNT_P2" 2>/dev/null || true
+    sudo umount -lf "$MOUNT_P3" 2>/dev/null || true
+    sudo losetup -d "$LOOP" 2>/dev/null || true
+    # cleanup the prod-work/rootfs and prod-work/boot work unsquashed directories
+    sudo rm -rf $WORKDIR
+}
+trap cleanup EXIT
+
+echo "Current pwd is ...${ROOTDIR}"
+sudo mkdir -p $WORKDIR
+sudo mkdir -p $ROOTFS
+
+echo "Creating target partition p3 mount point ...${MOUNT_P3}"
+sudo mkdir -p $MOUNT_P3
+
+echo "Removing existing raw disk images ..."
+files=$(find $ROOTDIR/iso-images/$BUILDTYPE -maxdepth 1 -type f -name "*.img")
+if [ -n "$files" ]; then
+    echo "Found .img files:"
+    echo "$files"
+    sudo find $ROOTDIR/iso-images/$BUILDTYPE -maxdepth 1 -type f -name "*.img" -delete
+fi
+sync
+
+echo "Creating raw disk image..."
+sudo truncate -s $SIZE "$IMG"
+
+echo "Attaching loop device..."
+LOOP=$(sudo losetup --show -fP "$IMG")
+
+echo "Partitioning disk..."
+
+sudo parted -s $LOOP mklabel gpt
+
+# p1: U-Boot environment (RAW ~256KB)
+sudo parted -s $LOOP mkpart UBOOT_ENV 1MiB 1.25MiB
+
+# p2: EFI (FAT32)
+sudo parted -s $LOOP mkpart EFI fat32 1.25MiB 513MiB
+sudo parted -s $LOOP set 2 esp on
+
+# p3: ROOT (EXT4)
+sudo parted -s $LOOP mkpart ROOT ext4 513MiB 100%
+
+sudo partprobe $LOOP
+sleep 2
+
+echo "Formatting filesystems..."
+
+# DO NOT format p1 (raw env partition)
+
+# Format EFI
+sudo mkfs.vfat -n EFI ${LOOP}p2
+
+# Format rootfs
+sudo mkfs.ext4 -L persistence ${LOOP}p3
+
+echo "Mounting target..."
+
+# Mount root FIRST (now p3)
+sudo mount ${LOOP}p3 "$MOUNT_P3"
+
+# Create EFI mountpoint inside rootfs
+sudo mkdir -p "$MOUNT_P2"
+
+# Mount EFI (p2)
+sudo mount ${LOOP}p2 "$MOUNT_P2"
+
+# Copy any customized uEnv.txt file for uboot into vFAT EFI partition
+echo "Copying uEnv file ${UENVFILE} to uEnv.txt in the EFI partition"
+sudo cp $UENVFILE $MOUNT_P2/uEnv.txt
+
+echo "Extracting root filesystem..."
+  
+if [[ ! -d "$ROOTFS" ]]; then
+    echo "Removing existing rootfs staging directory: $ROOTFS"
+    sudo rm -rf $ROOTFS
+fi
+
+sudo unsquashfs -f -d "$ROOTFS" "$ISOPATH_STAGE/live/filesystem.squashfs"
+
+echo "Preparing to chroot..."
+
+sudo mount --bind /dev "$ROOTFS/dev"
+sudo mount --bind /proc "$ROOTFS/proc"
+sudo mount --bind /sys "$ROOTFS/sys"
+sudo mount --bind /run "$ROOTFS/run"
+
+sudo mkdir -p "$ROOTFS/mnt/iso"
+sudo mount --bind "$ISOPATH_STAGE" "$ROOTFS/mnt/iso"
+
+echo "Running prod_image.py with GRUB target: $LOOP"
+# sudo chroot "$ROOTFS" ls -l "$LOOP"
+sudo chroot "$ROOTFS" python3 /usr/lib/python3/dist-packages/vyos/system/prod_image.py --grub-target "$LOOP"
+
+echo "==========================================================================="
+echo "Production firmware image build complete: $IMG"
+echo "==========================================================================="
+
+shopt -s nullglob
+if [[ "$BUILDTYPE" == "bookworm-am64xx-evm" ]]; then
+    set -- "$IMAGEPATH"/ti*-boot-emmc.squashfs
+elif [[ "$BUILDTYPE" == "bookworm-j7200-evm" ]]; then
+    set -- "$IMAGEPATH"/ti*-boot-emmc.squashfs
+else
+    set -- "$IMAGEPATH"/ti*-boot.squashfs
+fi
+
+if [[ ! -d "$IMAGEPATH" || $# -eq 0 ]]; then
+    echo "Warning: no boot squash image found in: $IMAGEPATH"
+else
+    echo "Unsquashing boot squash image $1 found in: $IMAGEPATH"
+    sudo unsquashfs -f -d "$UBOOTWORK" "$1"
+
+    sudo dd if=/dev/zero of=$BOOTIMG bs=1M count=7    
+
+    # tiboot3.bin @ 0x0
+    sudo dd if=$UBOOTWORK/tiboot3.bin of=$BOOTIMG bs=512 seek=0 conv=notrunc
+
+    # tispl.bin @ 0x800
+    sudo dd if=$UBOOTWORK/tispl.bin of=$BOOTIMG bs=512 seek=$((0x800)) conv=notrunc
+
+    # u-boot.img @ 0x1800
+    sudo dd if=$UBOOTWORK/u-boot.img of=$BOOTIMG bs=512 seek=$((0x1800)) conv=notrunc
+
+    echo "==========================================================================="
+    echo "Production boot image build complete: $BOOTIMG"
+    echo "==========================================================================="
+fi
+shopt -u nullglob
+
+

--- a/updates/uEnv/uEnv-am64x-evm.txt
+++ b/updates/uEnv/uEnv-am64x-evm.txt
@@ -1,0 +1,1 @@
+uenvcmd=load mmc 0:2 ${kernel_addr_r} /EFI/VyOS/grubaa64.efi; load mmc 0:3 ${fdt_addr_r} /boot/dtb/ti/k3-am642-evm.dtb; bootefi ${kernel_addr_r} ${fdt_addr_r}

--- a/updates/uEnv/uEnv-iolan.txt
+++ b/updates/uEnv/uEnv-iolan.txt
@@ -1,1 +1,1 @@
-uenvcmd=load mmc 0:2 ${kernel_addr_r} /EFI/VyOS/grubaa64.efi; load mmc 0:3 ${fdt_addr_r} /boot/dtb/ti/k3-am642-evm.dtb; bootefi ${kernel_addr_r} ${fdt_addr_r}
+uenvcmd=load mmc 0:2 ${kernel_addr_r} /EFI/VyOS/grubaa64.efi; load mmc 0:3 ${fdt_addr_r} /boot/dtb/ti/k3-am642-iolan.dtb; bootefi ${kernel_addr_r} ${fdt_addr_r}

--- a/updates/uEnv/uEnv-iolan.txt
+++ b/updates/uEnv/uEnv-iolan.txt
@@ -1,0 +1,1 @@
+uenvcmd=load mmc 0:2 ${kernel_addr_r} /EFI/VyOS/grubaa64.efi; load mmc 0:3 ${fdt_addr_r} /boot/dtb/ti/k3-am642-evm.dtb; bootefi ${kernel_addr_r} ${fdt_addr_r}

--- a/updates/uEnv/uEnv-j72x-evm.txt
+++ b/updates/uEnv/uEnv-j72x-evm.txt
@@ -1,1 +1,1 @@
-uenvcmd=load mmc 0:2 ${kernel_addr_r} /EFI/VyOS/grubaa64.efi; load mmc 0:3 ${fdt_addr_r} /boot/dtb/ti/k3-am642-evm.dtb; bootefi ${kernel_addr_r} ${fdt_addr_r}
+uenvcmd=load mmc 0:2 ${kernel_addr_r} /EFI/VyOS/grubaa64.efi; load mmc 0:3 ${fdt_addr_r} /boot/dtb/ti/k3-j7200-evm.dtb; bootefi ${kernel_addr_r} ${fdt_addr_r}

--- a/updates/uEnv/uEnv-j72x-evm.txt
+++ b/updates/uEnv/uEnv-j72x-evm.txt
@@ -1,0 +1,1 @@
+uenvcmd=load mmc 0:2 ${kernel_addr_r} /EFI/VyOS/grubaa64.efi; load mmc 0:3 ${fdt_addr_r} /boot/dtb/ti/k3-am642-evm.dtb; bootefi ${kernel_addr_r} ${fdt_addr_r}


### PR DESCRIPTION
Added new 'make prod-image' option in Makefile (for now due to disk space usage, it will NOT be done automatically by the make all process):
1) Creates a 14+ Gb (nominal 16Gb part) raw image with 3 partitions: 256k raw (boot env vars), 512 Mb EFI FAT (grub binary) and the rest EXT4 (grub config, factory firmware and current firmware (similar resulting layout from vyos' 'install image' cli command
2) Uses the iso-images/$(buildtype)/stage_iso iso contents as input for the raw image's grub and firmware image.
3) Copies a new uEnv.txt file (that automates the loading of dtb, grub and boot command) to the EFI/FAT partition with a required, modified uboot that supports using "uenvcmd=xxx" inside a uEnv.txt FAT file
4) Chroots and calls new vyos-1x's prod_image.py to install grub to EFI/FAT partition, and the grub config and factory/current firmware images to the EXT4 partition
5) Creates a raw boot image for flashing onto emmc boot partition 0, containing tiboot3.bin, tispl.bin, and u-boot.img at non-overlapping 512k block offsets 0x0000, 0x0800 and 0x1800 respectively for EVM boards (7MB) and 0x0000, 0x0700 and 0x1000 for am64x IOLAN target (4 MB)

On eval boards, the emmc boot and emmc firmware files can be flashed by booting from SD, inserting a USB flash drive containing the 2 img files from iso-images/$(buildtype)/igos-boot*.img and igos-prod*.img, mounting the usb drive to access the files and then use separate "dd" commands flash the emmc as follows:

sudo mkdir -p /mnt/sda
sudo mount /dev/sda2 /mnt/sda
ls -l /mnt/sda/igos*.img
echo 0 | sudo tee /sys/block/mmcblk0boot0/force_ro
sudo dd if=/mnt/sda/<igos-boot-*.img> of=/dev/mmcblk0boot0 bs=512 status=progress conv=fsync
sudo dd if=/mnt/sda/<igos-prod-*.img> of=/dev/mmcblk0 bs=4M status=progress conv=fsync

Integration with the Iolan target emmc will be next.  Since there is no support for SDcard and USB flash drive, I anticipate using the dfu-image method for burning emmc over jtag or tftp