### PR TITLE
Build robustification.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ISO_TARG      = .iso.built
 
 DATECODE := $(shell date +%Y%m%d%H%M%S00)
 
-.PHONY: help all test sdcard sdcard-squashfs live-iso dfuimg status clean mostlyclean targ-ti-am64x targ-ti-j7200 targ-x86 containerclean spotless
+.PHONY: help all test sdcard sdcard-squashfs live-iso dfuimg status clean mostlyclean targ-ti-am64x targ-ti-j7200 targ-x86 containerclean spotless prod-image
 
 help:
 	@echo First select a build type.  Valid types are:

--- a/bin/buildlog
+++ b/bin/buildlog
@@ -68,7 +68,7 @@ echo "$H Possible failures in $FILES"
 cat $FILES 2> /dev/null | \
     sed '/undefined reference to .timer_create./,/building .zmq.libzmq. extension/d' |
     egrep --color=always \
-        '(fatal:| error:|^\*\*\*|dpkg:.*error|no space left on device|Depends: [^ ]* but it is not)' |
+        '(fatal:| error:|^\*\*\*|dpkg:.*error|no space left on device|Depends: [^ ]* but it is not|E: An unexpected failure occurred)' |
     egrep -v '(Linking the executable xfrmi|libstrongswan-kernel-netlink.so is not portable|unable to read /etc/init.d/iperf3|/usr/sbin/grub-probe|bash-completion-test-subject.deb|NOTE: Filtering of link-warnings enabled)'
 echo $H
 

--- a/build_iGOS_TMDS64EVM_fs.sh
+++ b/build_iGOS_TMDS64EVM_fs.sh
@@ -174,7 +174,18 @@ if [ ! -f "$BLT" ]; then
     else
         # this section needs some rework to clean up how this ti firmware is pulled.
         sudo rm -rf debian-repos
-        git clone -b psl-master $REPO_URL_TI_DEB
+
+        # TI repos are flaky, so retries are needed
+        for i in 1 2 3
+        do
+            git clone -b psl-master $REPO_URL_TI_DEB && { i=''; break; }
+            st=$?
+            sleeptime=$((i * 30))
+            echo "warning: Clone $REPO_URL_TI_DEB failed (status $st); sleeping $sleeptime and retrying"
+            sleep $sleeptime
+        done
+        test -z "$i" || { echo "fatal: Cannot clone $REPO_URL_TI_DEB, giving up"; exit 1; }
+
         cd debian-repos
 
         # Determine the Debian distro to use


### PR DESCRIPTION
- Add prod-image to .PHONY because it is.
- Add another error string to buildlog that happens sporadically.
- Retry the git clone of the TI repo since it is flaky.
