### PR TITLE
fixes for emitting the product.env when eeprom has mac address env var and also limit i2c read to 0x100 due to the type of eeprom used

### DIFF
--- a/updates/uEnv/uEnv-iolan.txt
+++ b/updates/uEnv/uEnv-iolan.txt
@@ -1,7 +1,8 @@
 scratch_addr=0x82000000
 eeprom_addr=0x50
 eeprom_off=0
-eeprom_size=0x200
+eeprom_size=0x100
 test_reset=setexpr next_addr ${scratch_addr} + 4; gpio read buttonval 123; if test $buttonval -eq 1; then setenv second_half 0x0a303d74; else setenv second_half 0x0a313d74; fi; mw.l ${scratch_addr} 0x65736572 1; mw.l ${next_addr} ${second_half} 1;\ fatwrite mmc 0:2 ${scratch_addr} /RESET.ENV 8
-test_provision=i2c dev 0; if i2c read ${eeprom_addr} ${eeprom_off}.1 ${eeprom_size} ${scratch_addr}; then if itest.l *${scratch_addr} == 0xffffffff || itest.l *${scratch_addr} == 0x00000000; then if fatload mmc 0:2 ${scratch_addr} /PRODUCT.ENV; then env delete -f ethaddr; if env import -t ${scratch_addr} ${filesize}; then if env exists mac; then i2c write ${scratch_addr} ${eeprom_addr} ${eeprom_off}.1 ${filesize}; setenv ethaddr ${mac}; fi; fi; fi; else env delete -f ethaddr; if env import -t ${scratch_addr} ${eeprom_size}; then if env exists mac; then setenv ethaddr ${mac}; setenv bootargs ${bootargs} prod_id=${prod_id} model=${model}; fi; fi; fi; fi
+test_provision=i2c dev 0; if i2c read ${eeprom_addr} ${eeprom_off}.1 ${eeprom_size} ${scratch_addr}; then if itest.l *${scratch_addr} == 0xffffffff || itest.l *${scratch_addr} == 0x00000000; then if fatload mmc 0:2 ${scratch_addr} /PRODUCT.ENV; then env delete -f ethaddr; if env import -t ${scratch_addr} ${filesize}; then if env exists mac; then i2c write ${scratch_addr} ${eeprom_addr} ${eeprom_off}.1 ${filesize}; setenv ethaddr ${mac}; fi; fi; fi; else env delete -f ethaddr; if env import -t ${scratch_addr} ${eeprom_size}; then if env exists mac; then setenv ethaddr ${mac}; setenv bootargs ${bootargs} prod_id=${prod_id} model=${model}; fatwrite mmc 0:2 ${scratch_addr} /PRODUCT.ENV ${eeprom_size}; fi; fi; fi; fi
 uenvcmd=run test_reset; run test_provision; load mmc 0:2 ${kernel_addr_r} /EFI/VyOS/grubaa64.efi; load mmc 0:3 ${fdt_addr_r} /boot/dtb/ti/k3-am642-iolan.dtb; bootefi ${kernel_addr_r} ${fdt_addr_r}
+


### PR DESCRIPTION
Fixes for emitting the product.env when eeprom has mac address env var and also limit i2c read to 0x100 due to the type of eeprom used