### PR TITLE
Added additional env variables that will be stored in EEPROM and emitted to product.env in the FAT partition for linux/grub to access

### DIFF
--- a/updates/product.env.iolan
+++ b/updates/product.env.iolan
@@ -1,6 +1,6 @@
 prod_id=IOLAN
 model=2A01
-mac=00:80:ba:00:00:00
+mac=00:80:ba:00:00:28
 serial=300-01123456789
 ssid=psl123456789
 password=perle1


### PR DESCRIPTION
Sample product.env files define the proposed string format that will be stored in EEPROM by manufacturing diags.  The latest iolan uboot will check for /uEnv.txt and run the scripts inside including the uenvcmd= command.  Those uEnv.txt scripts will check eeprom and emit a /product.env text file with the eeprom contents to the mmcblk0p2 (FAT) partition so grub and linux can access the file directly.  It will also set the eth1 mac address to the mac=00:80:ba:xx:xx:xx before launching grub and linx. If the eeprom is empty (engineering prototypes), uboot will check for /product.env in the mmcblk0p2 FAT partition and write the contents to eeprom.  

Please note that these changes apply to the IOLAN target boards only.  Ensure the mac=00:80:ba:xx:xx:xx string is a UNIQUE mac address preserving the company OUI 00:80:ba (Chase/Perle), if manually copying a product.env file to mmcblk0p2, to avoid duplicate mac addresses in the lab/office.  If your eeprom is already setup with environment strings, it will overwrite any copied product.env in the mmcblk0p2 partition.  The only way to update the eeprom is break into uboot cli, clear the eeprom contents to FFs, and copy the desired /product.env to mmcblk0p2.  On the next reboot, uboot will copy the contents of /product.env to the eeprom