### PR TITLE
Add support for building OpenSSH 10.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ endif
 
 # Build the root filesystem
 $(FS_TARG): $(UBOOT_TARG)
+	@$(call DOCKRUN,openssh,./build_iGOS_openssh_fs.sh)
 	@$(call DOCKRUN,filesystem,./build_iGOS_TMDS64EVM_fs.sh)
 
 # Create a uSDcard image

--- a/build_iGOS_TMDS64EVM_fs.sh
+++ b/build_iGOS_TMDS64EVM_fs.sh
@@ -120,6 +120,8 @@ if [ ! -f "$BLT" ]; then
             ;;
         *isc-kea-doc*)  # isc-kea insists on this
             ;;
+        *libwtmpdb-dev*)  # Needed for openssh 10.4
+            ;;
         *-dev_*|*-dbg_*|*-doc_*|*-dbgsym_*)  # Unwanted general patterns
             continue
             ;;
@@ -133,6 +135,9 @@ if [ ! -f "$BLT" ]; then
             continue
             ;;
         */salt-api_*.deb|*/salt-syndic_*.deb|*/salt-dbg_*.deb|*/salt-master_*.deb|*/salt-cloud_*.deb|*/salt-ssh_*.deb)  # Unwanted salt components
+            continue
+            ;;
+	*/wtmpdb*.deb)  # Breaks linux-utils
             continue
             ;;
         esac

--- a/build_iGOS_openssh_fs.sh
+++ b/build_iGOS_openssh_fs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -ex
+
+# Check if the --repo parameter is provided
+if [ "$#" -lt 2 ] || [ "$1" != "--repo" ]; then
+    echo "Usage: $0 --repo <repository_url> [--clean]"
+    exit 1
+fi
+
+ARCH=$(dpkg-architecture -qDEB_HOST_ARCH)
+
+REPPREFIX_URL="$2"
+REPO_URL_TI_DEB="$REPPREFIX_URL/debian-repos"
+REPO_NAME="vyos-build"
+REPO_URL="$REPPREFIX_URL/$REPO_NAME"
+ROOTDIR=$(pwd)
+
+# Check if the --clean parameter is provided
+CLEAN=false
+if [ "$#" -eq 3 ] && [ "$3" == "--clean" ]; then
+    CLEAN=true
+fi
+
+# Delete the repository if it already exists and --clean is specified
+if [ -d "$REPO_NAME" ]; then
+    if [ "$CLEAN" = true ]; then
+        echo "Cleaning up existing repository $REPO_NAME."
+        sudo rm -rf "$REPO_NAME"
+        rm -f .filesystem.* # Also remove all intermediate targets
+    else
+        echo "Repository $REPO_NAME already exists. Skipping clone."
+    fi
+fi
+
+# Clone the repository if it doesn't exist or was cleaned
+if [ ! -d "$REPO_NAME" ]; then
+    git clone -b psl-master --single-branch "$REPO_URL"
+#    git clone -b vyos-build-jf --single-branch "$REPO_URL"
+fi
+
+# Install build_flavor
+cp -f $ROOTDIR/updates/arm64fs.toml $ROOTDIR/vyos-build/data/build-flavors/
+
+############## package-build-iGOS
+# This will build openssh-10.4 in ./vyos-build/scripts/package-build-iGOS/
+TSK=package-build-openSSH
+BLT=.filesystem.$TSK.built
+OPENSSH="openssh-10.4"
+if [ ! -f "$BLT" ]; then
+    echo "=== I: $0: package-build.py $TSK BEGIN"
+    ./package-build.py --dir package-build-iGOS --include $OPENSSH
+    touch "$BLT" # build success
+else
+    echo "=== I: $0: SKIP package-build.py $TSK ($BLT exists)"
+fi
+
+
+echo "=== I: $0: COMPLETED"


### PR DESCRIPTION
Add build commands in nexus build for OpenSSH 10.4.  Re-implementing PR #56 but with the package.toml moved to vyos-build. 

The process involves adding a new script to build specifically OpenSSH, so that only it is built in a separate docker call.  This is required to ensure that required backport dependencies that are installed do not taint the docker for future steps (which is what would happen if it was added with the rest of the other igos packages listed).  In addition, changes were made to the filesystem script to ensure that certain built dependencies .debs are included, while others are excluded due to causing backport dependency issues.